### PR TITLE
Add Fang Cabrera inspired blog layout and styles

### DIFF
--- a/blog.css
+++ b/blog.css
@@ -1,0 +1,231 @@
+/* Fang Cabrera inspired blog styles */
+:root {
+  --bg-primary: #ffffff;
+  --bg-muted: #fafafa;
+  --text-primary: #0a0a0a;
+  --text-secondary: #6b7280;
+  --border: #e5e7eb;
+  --accent: #111827;
+  --accent-hover: #000000;
+  --code-bg: #0b1020;
+  --code-text: #e5e7eb;
+  --selection-bg: #111827;
+  --selection-text: #ffffff;
+
+  --shadow-soft: 0 10px 30px rgba(0,0,0,0.06);
+  --content-width: 72ch;
+  --measure: 65ch;
+  --gutter: clamp(1rem,4vw,2rem);
+  --section-gap: 6rem;
+  --radius: 1.25rem;
+
+  --font-heading: 'Inter', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, 'Apple Color Emoji', 'Segoe UI Emoji';
+  --font-body: Georgia, Cambria, 'Times New Roman', Times, serif;
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+
+  --h1: clamp(2.25rem, 5vw, 3rem);
+  --h2: clamp(1.75rem, 3.5vw, 2.25rem);
+  --h3: 1.375rem;
+  --body: 1.0625rem;
+  --small: 0.9375rem;
+
+  --lh-heading: 1.15;
+  --lh-body: 1.75;
+  --ls-caps: 0.04em;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  font-family: var(--font-body);
+  font-size: var(--body);
+  line-height: var(--lh-body);
+  color: var(--text-primary);
+  background: var(--bg-primary);
+}
+
+::selection {
+  background: var(--selection-bg);
+  color: var(--selection-text);
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+}
+
+/* Typography */
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-heading);
+  line-height: var(--lh-heading);
+  color: var(--text-primary);
+}
+
+h1 { font-size: var(--h1); }
+h2 { font-size: var(--h2); }
+h3 { font-size: var(--h3); }
+
+p { margin-top: 1.25rem; }
+
+/* Links */
+a {
+  color: var(--accent);
+  text-decoration: none;
+  transition: color 150ms ease, text-decoration-color 150ms ease;
+}
+
+a:hover {
+  color: var(--accent-hover);
+  text-decoration: underline;
+  text-underline-offset: 4px;
+  text-decoration-thickness: 1px;
+}
+
+/* Layout */
+main {
+  max-width: var(--content-width);
+  margin: 0 auto;
+  padding: 0 var(--gutter);
+}
+
+section {
+  padding-block: var(--section-gap);
+}
+
+/* Header */
+.site-header {
+  position: sticky;
+  top: 0;
+  background: rgba(255,255,255,0.7);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--border);
+  z-index: 10;
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  max-width: var(--content-width);
+  margin: 0 auto;
+  padding: 1rem var(--gutter);
+}
+
+.logo {
+  font-family: var(--font-heading);
+  font-weight: 600;
+  font-size: 1.125rem;
+  letter-spacing: var(--ls-caps);
+}
+
+.nav-links {
+  list-style: none;
+  display: flex;
+  gap: 1.5rem;
+  text-transform: uppercase;
+  letter-spacing: var(--ls-caps);
+  font-size: var(--small);
+}
+
+.nav-links a { color: var(--text-secondary); }
+.nav-links a:hover { color: var(--accent); }
+.nav-links a.active {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 4px;
+  text-decoration-thickness: 1px;
+}
+
+/* Hero */
+.hero .kicker {
+  font-family: var(--font-heading);
+  text-transform: uppercase;
+  letter-spacing: var(--ls-caps);
+  color: var(--text-secondary);
+  font-size: var(--small);
+}
+
+.hero h1 { margin-top: 0.5rem; }
+.hero-desc { color: var(--text-secondary); margin-top: 1rem; max-width: var(--measure); }
+
+/* Post list */
+.post-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+  margin-top: 2rem;
+}
+
+.post-item {
+  transition: transform 150ms ease, box-shadow 150ms ease;
+  padding: 0.5rem 0;
+}
+
+.post-item:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-soft);
+}
+
+.post-title {
+  font-weight: 700;
+  line-height: 1.3;
+}
+
+.post-meta {
+  font-size: var(--small);
+  color: var(--text-secondary);
+  margin-top: 0.25rem;
+}
+
+.post-divider {
+  height: 1px;
+  background: var(--border);
+}
+
+/* Article prose */
+article {
+  max-width: var(--measure);
+}
+
+article p { margin-top: 1.25rem; }
+
+article blockquote {
+  border-left: 2px solid var(--border);
+  padding-left: 1rem;
+  color: var(--text-secondary);
+  font-style: italic;
+}
+
+article code {
+  font-family: var(--font-mono);
+  background: #f3f4f6;
+  padding: 0.1em 0.3em;
+  border-radius: 4px;
+}
+
+pre {
+  font-family: var(--font-mono);
+  background: var(--code-bg);
+  color: var(--code-text);
+  padding: 1rem;
+  border-radius: var(--radius);
+  overflow: auto;
+  margin-top: 1.25rem;
+}
+
+/* Footer */
+.site-footer {
+  border-top: 1px solid var(--border);
+  padding: 2rem var(--gutter);
+  text-align: center;
+  font-size: var(--small);
+  color: var(--text-secondary);
+}

--- a/blog.html
+++ b/blog.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Blog | Vidya Sagar Reddy Venna</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="blog.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <nav class="nav">
+        <a href="index.html" class="logo">VS</a>
+        <ul class="nav-links">
+          <li><a href="index.html#about">About</a></li>
+          <li><a href="index.html#projects">Projects</a></li>
+          <li><a href="blog.html" class="active">Blog</a></li>
+          <li><a href="index.html#contact">Contact</a></li>
+        </ul>
+      </nav>
+    </header>
+
+    <main>
+      <section class="hero">
+        <p class="kicker">Latest writing</p>
+        <h1>Blog</h1>
+        <p class="hero-desc">Thoughts on engineering, research, and learning.</p>
+      </section>
+
+      <section class="post-list">
+        <article class="post-item">
+          <h2 class="post-title"><a href="#">Generative Models for Time Series</a></h2>
+          <p class="post-meta">July 24, 2024 · 5 min read</p>
+          <p>Exploring hidden structure in sequential data with simple generative approaches.</p>
+        </article>
+        <div class="post-divider"></div>
+        <article class="post-item">
+          <h2 class="post-title"><a href="#">Notes on Diffusion Models</a></h2>
+          <p class="post-meta">June 12, 2024 · 8 min read</p>
+          <p>A gentle walkthrough of diffusion-based generative models and why they work.</p>
+        </article>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <p>© 2024 Vidya Sagar Reddy Venna. Inspired by Fang Cabrera.</p>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add standalone blog page with sticky nav and sample posts
- implement light, minimalist theme with serif body text, airy spacing, and subtle hover interactions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a8548d5e88326b03d309da85f1f42